### PR TITLE
Minor fixes

### DIFF
--- a/azure-iot-edge/modules/BlueWalker/module.json
+++ b/azure-iot-edge/modules/BlueWalker/module.json
@@ -4,7 +4,7 @@
   "image": {
     "repository": "openiotplatform.azurecr.io/denim/bluewalker",
     "tag": {
-      "version": "0.0.5",
+      "version": "0.0.6",
       "platforms": {
         "amd64": "./Dockerfile.amd64",
         "amd64.debug": "./Dockerfile.amd64.debug",

--- a/azure-iot-edge/modules/RuuviTagGateway/app.js
+++ b/azure-iot-edge/modules/RuuviTagGateway/app.js
@@ -67,6 +67,10 @@ const handleDeviceRegistrationMessage = iotHubMsg => {
     console.log("wasSuccessful", wasSuccessful);
 
     const device = devices.find((d) => { return d.address === registrationId });
+    if (!device) {
+        console.log(`Device with id ${registrationId} not found`);
+        return
+    }
     if (wasSuccessful && (device.status === "WAITING" || device.status === "DENIED")) {
         device.status = "REGISTERED";
         device.timeToRetry = null;

--- a/azure-iot-edge/modules/RuuviTagGateway/app.js
+++ b/azure-iot-edge/modules/RuuviTagGateway/app.js
@@ -190,7 +190,7 @@ const unixServer = net.createServer(socket => {
                 humidity: telemetry.sensors.humidity,
                 pressure: telemetry.sensors.pressure,
                 voltage: telemetry.sensors.voltage,
-                txpower: telemetry.sensors.txpower,
+                tx_power: telemetry.sensors.txpower,
                 time: new Date().toISOString()
             };
 

--- a/azure-iot-edge/modules/RuuviTagGateway/module.json
+++ b/azure-iot-edge/modules/RuuviTagGateway/module.json
@@ -4,7 +4,7 @@
     "image": {
         "repository": "openiotplatform.azurecr.io/denim/ruuvi-tag-gateway",
         "tag": {
-            "version": "0.0.5",
+            "version": "0.0.6",
             "platforms": {
                 "amd64": "./Dockerfile.amd64",
                 "amd64.debug": "./Dockerfile.amd64.debug",


### PR DESCRIPTION
Couple of fixes:

- Fixed the possible "device.status is undefined" error which can happen if ruuvitag-gateway module restarts after sending device registration messages and backend tries to invoke the method as soon gateway is running but before device is added back to devices array.

- Send the module and method name to use as a callbacks in device registration. Before these were hardcoded in the db-api backend

- Changed the txpower field in telemetry data to tx_power to match the database column name in the new database. It is simpler to add a support for inserting to multiple telemetry tables if we require that field names in telemetry messages match the column names in the database.